### PR TITLE
Create lgtm.yml for C/C++ analysis by LGTM.com

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,12 @@
+extraction:
+  cpp:
+    after_prepare:
+      - wget -O bdwgc.zip "https://github.com/ivmai/bdwgc/archive/master.zip?foo=`date +%s`"
+      - unzip bdwgc.zip
+      - mv bdwgc-master bdwgc
+    configure:
+      command:
+        - cmake -G "Unix Makefiles"
+    index:
+      build_command:
+        - cmake --build . --config Release


### PR DESCRIPTION
Hi @Wodan58,

I noticed that you tried to set up automated code review on LGTM.com, but that the C/C++ analysis wasn't working. This configuration file gives LGTM.com the right instructions to build your code.

Note that doing a "git clone" during the build process is unfortunately not supported due to proxy/caching optimisations. However, a regular HTTP(s) request works fine — that's how I pull in `bdwgc`. A good alternative would be to use Git submodules.

The first results (using this configuration) are now in: https://lgtm.com/projects/g/Wodan58/joy1/alerts/

And the automated code review will also start analysing the C/C++ code.

Hartelijke groeten uit Oxford!

(full disclosure: I'm part of the team responsible for LGTM)