### PR TITLE
Fix crash in getenv

### DIFF
--- a/interp.c
+++ b/interp.c
@@ -373,7 +373,7 @@ PRIVATE void getenv_()
 
     ONEPARAM("getenv");
     STRING("getenv");
-    UNARY(STRING_NEWNODE, str = getenv(stk->u.str) ? str : ""); }
+    UNARY(STRING_NEWNODE, (str = getenv(stk->u.str)) ? str : ""); }
 
 PRIVATE void body_()
 {


### PR DESCRIPTION
Assignment has lower precedence than ternary conditional. This causes the str variable to be re-assigned its as-of-yet uninitialized value.